### PR TITLE
chore: add start and test:watch run-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
     "index.js.map"
   ],
   "scripts": {
+    "start": "npm run test:watch",
     "clean": "rm -f index.js index.js.map tests/*.js tests/*.js.map",
     "prebuild": "npm run clean",
     "build": "tsc --sourceMap",
     "pretest": "tsc --inlineSourceMap",
     "test": "mocha --compilers js:babel-register 'tests/**/*-test.js'",
+    "test:watch": "chokidar --initial \"index.ts\" -c \"npm run test -- --watch\"",
     "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -w",
     "preversion": "npm test",
@@ -39,6 +41,7 @@
     "babel-preset-es2015": "6.6.0",
     "babel-register": "6.6.5",
     "chai": "3.5.0",
+    "chokidar-cli": "1.2.0",
     "coveralls": "2.11.9",
     "cz-conventional-changelog": "1.1.5",
     "in-publish": "2.0.0",


### PR DESCRIPTION
*  add `start` run-script aliasing `test:watch`
*  use `chokidar-cli` to enable simultaneous source and test watching