### PR TITLE
Avoid duplicate React import

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -94,7 +94,6 @@ export function generateFromAst(moduleName: string, ast: any, options: IOptions 
   const generator: Generator = options.generator || new Generator();
 
   const generateTypings: () => void = () => {
-    generator.import('* as React', 'react');
     if (propTypes) {
       Object.keys(propTypes).forEach((propName: string) => {
         const prop: IProp = propTypes[propName];
@@ -112,6 +111,9 @@ export function generateFromAst(moduleName: string, ast: any, options: IOptions 
   };
 
   if (moduleName === null) {
+    if (!options.generator) {
+      generator.import('* as React', 'react');
+    }
     generateTypings();
   } else {
     generator.declareModule(moduleName, generateTypings);
@@ -343,6 +345,7 @@ export class Generator {
     this.code += `declare module '${name}' {`;
     this.nl();
     this.indentLevel++;
+    this.import('* as React', 'react');
     fn();
     this.indentLevel--;
     this.indent();

--- a/tests/generator-test.ts
+++ b/tests/generator-test.ts
@@ -10,7 +10,7 @@ describe('The Generator', () => {
     generator.declareModule('name', () => {
       //
     });
-    assert.equal(generator.toString(), "declare module 'name' {\n}\n");
+    assert.equal(generator.toString(), "declare module 'name' {\n\timport * as React from 'react';\n}\n");
   });
   it('should write an import statement', () => {
     generator.import('decls', 'from');

--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import * as react2dts from '../index';
+import { Generator } from '../index';
 
 describe('Parsing', () => {
   it('should create definition from es6 class component', () => {
@@ -39,6 +40,20 @@ describe('Parsing', () => {
     assert.equal(
       react2dts.generateFromFile('component', path.join(__dirname, 'es7-class-babeled.js'), opts),
       fs.readFileSync(path.join(__dirname, 'es7-class.d.ts')).toString()
+    );
+  });
+  it('should create definition using generator', () => {
+    let generator: Generator = new Generator();
+    const opts: react2dts.IOptions = {
+      instanceOfResolver: (name: string): string => './path/to/Message',
+      generator: generator
+    };
+    generator.declareModule('component', () => {
+      react2dts.generateFromFile(null, path.join(__dirname, 'es6-class.jsx'), opts)
+    });
+    assert.equal(
+      generator.toString(),
+      fs.readFileSync(path.join(__dirname, 'es6-class.d.ts')).toString()
     );
   });
 });


### PR DESCRIPTION
Avoid duplicate React import `import * as React from 'react'` when  to write multiple declarations into one .d.ts file.
