### PR TITLE
feat: export complex types as type aliases or interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "babylon": "6.15.0",
     "dts-dom": "0.1.12",
     "get-stdin": "5.0.1",
-    "meow": "3.7.0"
+    "meow": "3.7.0",
+    "pascal-case": "2.0.0"
   },
   "config": {
     "commitizen": {

--- a/tests/es6-class.d.ts
+++ b/tests/es6-class.d.ts
@@ -1,6 +1,13 @@
 declare module 'component' {
     import * as React from 'react';
     import Message from './path/to/Message';
+    export type ComponentOptionalEnum = 'News' | 'Photos' | 1 | 2;
+    export type ComponentOptionalUnion = string | number;
+    export interface ComponentOptionalObjectWithShape {
+        color?: string;
+        fontSize?: number;
+    }
+    export type ComponentRequiredUnion = any[] | boolean;
     export interface ComponentProps {
         /**
          * This is a jsdoc comment for optionalAny.
@@ -15,16 +22,13 @@ declare module 'component' {
         optionalNode?: React.ReactNode;
         optionalElement?: React.ReactElement<any>;
         optionalMessage?: typeof Message;
-        optionalEnum?: 'News' | 'Photos' | 1 | 2;
-        optionalUnion?: string | number;
+        optionalEnum?: ComponentOptionalEnum;
+        optionalUnion?: ComponentOptionalUnion;
         optionalArrayOf?: number[];
-        optionalObjectWithShape?: {
-            color?: string;
-            fontSize?: number;
-        };
+        optionalObjectWithShape?: ComponentOptionalObjectWithShape;
         requiredFunc: (...args: any[])=>any;
         requiredAny: any;
-        requiredUnion: any[] | boolean;
+        requiredUnion: ComponentRequiredUnion;
         requiredArrayOf: string[];
         requiredArrayOfObjectsWithShape: {
             color?: string;

--- a/tests/es7-class-top-level-module.d.ts
+++ b/tests/es7-class-top-level-module.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import Message from './path/to/Message';
+export type ComponentOptionalUnion = string | number;
+export type ComponentRequiredUnion = any[] | boolean;
 export interface ComponentProps {
     /**
      * This is a jsdoc comment for optionalAny.
@@ -14,11 +16,11 @@ export interface ComponentProps {
     optionalNode?: React.ReactNode;
     optionalElement?: React.ReactElement<any>;
     optionalMessage?: typeof Message;
-    optionalUnion?: string | number;
+    optionalUnion?: ComponentOptionalUnion;
     optionalArrayOf?: number[];
     requiredFunc: (...args: any[])=>any;
     requiredAny: any;
-    requiredUnion: any[] | boolean;
+    requiredUnion: ComponentRequiredUnion;
     requiredArrayOf: string[];
 }
 export default class Component extends React.Component<ComponentProps, any>{

--- a/tests/es7-class.d.ts
+++ b/tests/es7-class.d.ts
@@ -1,6 +1,8 @@
 declare module 'component' {
     import * as React from 'react';
     import Message from './path/to/Message';
+    export type ComponentOptionalUnion = string | number;
+    export type ComponentRequiredUnion = any[] | boolean;
     export interface ComponentProps {
         /**
          * This is a jsdoc comment for optionalAny.
@@ -15,11 +17,11 @@ declare module 'component' {
         optionalNode?: React.ReactNode;
         optionalElement?: React.ReactElement<any>;
         optionalMessage?: typeof Message;
-        optionalUnion?: string | number;
+        optionalUnion?: ComponentOptionalUnion;
         optionalArrayOf?: number[];
         requiredFunc: (...args: any[])=>any;
         requiredAny: any;
-        requiredUnion: any[] | boolean;
+        requiredUnion: ComponentRequiredUnion;
         requiredArrayOf: string[];
     }
     export default class Component extends React.Component<ComponentProps, any>{

--- a/tests/references-in-proptypes.d.ts
+++ b/tests/references-in-proptypes.d.ts
@@ -1,10 +1,12 @@
 declare module 'component' {
     import * as React from 'react';
+    export type SomeComponentSomeOneOf = 'foo' | 'bar';
+    export interface SomeComponentSomeShape {
+        string?: string;
+    }
     export interface SomeComponentProps {
-        someEnum?: 'foo' | 'bar';
-        someShape?: {
-            string?: string;
-        };
+        someOneOf?: SomeComponentSomeOneOf;
+        someShape?: SomeComponentSomeShape;
     }
     export default class SomeComponent extends React.Component<SomeComponentProps, any>{
     }

--- a/tests/references-in-proptypes.jsx
+++ b/tests/references-in-proptypes.jsx
@@ -5,7 +5,7 @@ const shape = { string: React.PropTypes.string };
 
 export default class SomeComponent extends React.Component {
    static propTypes = {
-     someEnum: React.PropTypes.oneOf(fooOrBar),
+     someOneOf: React.PropTypes.oneOf(fooOrBar),
      someShape: React.PropTypes.shape(shape)
    };
 }


### PR DESCRIPTION
Union, intersection and object types are now exported as well, along with the component props interface.