### PR TITLE
fix(typings): handle one more type of es6 exports

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -372,6 +372,8 @@ function getComponentExportType(ast: AstQuery, componentName: string): dom.Decla
           // VariableDeclaration
           / VariableDeclarator
           /:id Identifier[@name == '${componentName}']
+        ||
+          /Identifier[@name == '${componentName}']
       ]
     ,
       // AssignmentExpression[

--- a/tests/es7-class-separate-export.d.ts
+++ b/tests/es7-class-separate-export.d.ts
@@ -1,0 +1,8 @@
+declare module 'component' {
+    import * as React from 'react';
+    export interface ComponentProps {
+        optionalAny?: any;
+    }
+    export default class Component extends React.Component<ComponentProps, any>{
+    }
+}

--- a/tests/es7-class-separate-export.jsx
+++ b/tests/es7-class-separate-export.jsx
@@ -1,0 +1,16 @@
+import {Component, PropTypes} from 'react';
+
+class Component extends Component {
+
+	static propTypes = {
+		optionalAny: PropTypes.any,
+	};
+
+	render() {
+		return (
+			<div />
+		);
+	}
+}
+
+export default Component;

--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -55,6 +55,9 @@ test('Parsing should create definition from babeled es7 class component', t => {
   };
   compare(t, 'component', 'es7-class-babeled.js', 'es7-class.d.ts', opts);
 });
+test('Parsing should create definition from es7 class component with separate default export', t => {
+  compare(t, 'component', 'es7-class-separate-export.jsx', 'es7-class-separate-export.d.ts');
+});
 test('Parsing should create definition from stateless function component', t => {
   compare(t, 'component', 'stateless.jsx', 'stateless.d.ts');
 });


### PR DESCRIPTION
Fix for https://github.com/KnisterPeter/react-to-typescript-definitions/issues/286