### PR TITLE
refactor: use named imports in favor of import all

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -33,7 +33,7 @@ export function createTypings(moduleName: string|null, programAst: any, options:
 
   const m = dom.create.module(moduleName || 'moduleName');
   if (hasReactClass(ast, reactComponentName)) {
-    m.members.push(dom.create.importAll('React', 'react'));
+    m.members.push(dom.create.importNamed('Component', 'react'));
   }
   if (importStatements.length > 0) {
     importStatements.forEach(importStatement => {
@@ -80,7 +80,7 @@ function createExportedTypes(m: dom.ModuleDeclaration, ast: AstQuery, componentN
 
   if (classComponent) {
     const classDecl = dom.create.class(componentName);
-    classDecl.baseType = dom.create.interface(`React.Component<${interf.name}, any>`);
+    classDecl.baseType = dom.create.interface(`Component<${interf.name}, any>`);
     classDecl.flags = exportType;
     m.members.push(classDecl);
   } else {

--- a/tests/component-without-proptyes.d.ts
+++ b/tests/component-without-proptyes.d.ts
@@ -1,10 +1,10 @@
 declare module 'component' {
-  import * as React from 'react';
+  import {Component} from 'react';
 
   export interface TestProps {
   }
 
-  export default class Test extends React.Component<TestProps, any> {
+  export default class Test extends Component<TestProps, any> {
   }
 
   export function test(): JSX.Element;

--- a/tests/es6-class.d.ts
+++ b/tests/es6-class.d.ts
@@ -1,5 +1,5 @@
 declare module 'component' {
-  import * as React from 'react';
+  import {Component} from 'react';
 
   import Message from './path/to/Message';
 
@@ -52,6 +52,6 @@ declare module 'component' {
     requiredSymbol: typeof Symbol;
   }
 
-  export class Component extends React.Component<ComponentProps, any> {
+  export class Component extends Component<ComponentProps, any> {
   }
 }

--- a/tests/es7-class-separate-export.d.ts
+++ b/tests/es7-class-separate-export.d.ts
@@ -1,10 +1,10 @@
 declare module 'component' {
-  import * as React from 'react';
+  import {Component} from 'react';
 
   export interface ComponentProps {
     optionalAny?: any;
   }
 
-  export default class Component extends React.Component<ComponentProps, any> {
+  export default class Component extends Component<ComponentProps, any> {
   }
 }

--- a/tests/es7-class-top-level-module.d.ts
+++ b/tests/es7-class-top-level-module.d.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Component} from 'react';
 import Message from './path/to/Message';
 
 export type ComponentOptionalUnion = string | number;
@@ -27,5 +27,5 @@ export interface ComponentProps {
   requiredArrayOf: string[];
 }
 
-export default class Component extends React.Component<ComponentProps, any> {
+export default class Component extends Component<ComponentProps, any> {
 }

--- a/tests/es7-class.d.ts
+++ b/tests/es7-class.d.ts
@@ -1,5 +1,5 @@
 declare module 'component' {
-  import * as React from 'react';
+  import {Component} from 'react';
   import Message from './path/to/Message';
 
   export type ComponentOptionalUnion = string | number;
@@ -28,6 +28,6 @@ declare module 'component' {
     requiredArrayOf: string[];
   }
 
-  export default class Component extends React.Component<ComponentProps, any> {
+  export default class Component extends Component<ComponentProps, any> {
   }
 }

--- a/tests/import-react-component.d.ts
+++ b/tests/import-react-component.d.ts
@@ -1,3 +1,3 @@
 declare module 'component' {
-  import * as React from 'react';
+  import {Component} from 'react';
 }

--- a/tests/instance-of-proptype-names.d.ts
+++ b/tests/instance-of-proptype-names.d.ts
@@ -1,11 +1,11 @@
 declare module 'component' {
-  import * as React from 'react';
+  import {Component} from 'react';
   import Member from './member';
 
   export interface TestProps {
     test?: typeof Member;
   }
 
-  export class Test extends React.Component<TestProps, any> {
+  export class Test extends Component<TestProps, any> {
   }
 }

--- a/tests/references-in-proptypes.d.ts
+++ b/tests/references-in-proptypes.d.ts
@@ -1,5 +1,5 @@
 declare module 'component' {
-  import * as React from 'react';
+  import {Component} from 'react';
 
   export type SomeComponentSomeOneOf = 'foo' | 'bar';
 
@@ -12,6 +12,6 @@ declare module 'component' {
     someShape?: SomeComponentSomeShape;
   }
 
-  export default class SomeComponent extends React.Component<SomeComponentProps, any> {
+  export default class SomeComponent extends Component<SomeComponentProps, any> {
   }
 }

--- a/tests/unnamed-default-export.d.ts
+++ b/tests/unnamed-default-export.d.ts
@@ -1,11 +1,11 @@
 declare module 'path' {
-  import * as React from 'react';
+  import {Component} from 'react';
 
   export interface Props {
         onClick?: (...args: any[]) => any;
   }
 
-  export default class extends React.Component<Props, any> {
+  export default class extends Component<Props, any> {
     render(): JSX.Element;
   }
 }


### PR DESCRIPTION
For future support of non-react libraries we switched to named imports