### PR TITLE
refactor: add render method to typings

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -82,6 +82,7 @@ function createExportedTypes(m: dom.ModuleDeclaration, ast: AstQuery, componentN
     const classDecl = dom.create.class(componentName);
     classDecl.baseType = dom.create.interface(`React.Component<${interf.name}, any>`);
     classDecl.flags = exportType;
+    classDecl.members.push(dom.create.method('render', [], dom.create.namedTypeReference('JSX.Element')));
     m.members.push(classDecl);
   } else {
     const funcDelc = dom.create.function(componentName, propTypes ? [dom.create.parameter('props', interf)] : [],

--- a/tests/component-without-proptyes.d.ts
+++ b/tests/component-without-proptyes.d.ts
@@ -5,6 +5,7 @@ declare module 'component' {
   }
 
   export default class Test extends React.Component<TestProps, any> {
+    render(): JSX.Element;
   }
 
   export function test(): JSX.Element;

--- a/tests/es6-class.d.ts
+++ b/tests/es6-class.d.ts
@@ -53,5 +53,6 @@ declare module 'component' {
   }
 
   export class Component extends React.Component<ComponentProps, any> {
+    render(): JSX.Element;
   }
 }

--- a/tests/es7-class-separate-export.d.ts
+++ b/tests/es7-class-separate-export.d.ts
@@ -6,5 +6,6 @@ declare module 'component' {
   }
 
   export default class Component extends React.Component<ComponentProps, any> {
+    render(): JSX.Element;
   }
 }

--- a/tests/es7-class-top-level-module.d.ts
+++ b/tests/es7-class-top-level-module.d.ts
@@ -28,4 +28,5 @@ export interface ComponentProps {
 }
 
 export default class Component extends React.Component<ComponentProps, any> {
+  render(): JSX.Element;
 }

--- a/tests/es7-class.d.ts
+++ b/tests/es7-class.d.ts
@@ -29,5 +29,6 @@ declare module 'component' {
   }
 
   export default class Component extends React.Component<ComponentProps, any> {
+    render(): JSX.Element;
   }
 }

--- a/tests/instance-of-proptype-names.d.ts
+++ b/tests/instance-of-proptype-names.d.ts
@@ -7,5 +7,6 @@ declare module 'component' {
   }
 
   export class Test extends React.Component<TestProps, any> {
+    render(): JSX.Element;
   }
 }

--- a/tests/references-in-proptypes.d.ts
+++ b/tests/references-in-proptypes.d.ts
@@ -13,5 +13,6 @@ declare module 'component' {
   }
 
   export default class SomeComponent extends React.Component<SomeComponentProps, any> {
+    render(): JSX.Element;
   }
 }

--- a/tests/unnamed-default-export.d.ts
+++ b/tests/unnamed-default-export.d.ts
@@ -6,5 +6,6 @@ declare module 'path' {
   }
 
   export default class extends React.Component<Props, any> {
+    render(): JSX.Element;
   }
 }


### PR DESCRIPTION
To support preact we need to have a render method in our components