### PR TITLE
feat: resolve referenced propTypes

### DIFF
--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -84,6 +84,9 @@ test('Parsing should create definition from file without propTypes', t => {
 test('Parsing should create definition from file with references in propTypes', t => {
   compare(t, 'component', 'references-in-proptypes.jsx', 'references-in-proptypes.d.ts');
 });
+test('Parsing should create definition from file with reference as propTypes', t => {
+  compare(t, 'component', 'reference-as-proptypes.jsx', 'reference-as-proptypes.d.ts');
+});
 test('Parsing should create definition from file with unnamed default export', t => {
   compare(t, 'path', 'unnamed-default-export.jsx', 'unnamed-default-export.d.ts');
 });

--- a/tests/reference-as-proptypes.d.ts
+++ b/tests/reference-as-proptypes.d.ts
@@ -1,0 +1,11 @@
+declare module 'component' {
+  import {Component} from 'react';
+
+  export interface SomeComponentProps {
+    someString?: string;
+  }
+
+  export default class SomeComponent extends Component<SomeComponentProps, any> {
+    render(): JSX.Element;
+  }
+}

--- a/tests/reference-as-proptypes.jsx
+++ b/tests/reference-as-proptypes.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+class SomeInternalComponent extends React.Component {
+   static propTypes = {
+     someString: React.PropTypes.string
+   };
+}
+
+export default class SomeComponent extends React.Component {
+   static propTypes = SomeInternalComponent.propTypes;
+}


### PR DESCRIPTION
Example (`reference-as-proptypes.jsx` in tests):

```js
import React from 'react';

class SomeInternalComponent extends React.Component {
   static propTypes = {
     someString: React.PropTypes.string
   };
}

export default class SomeComponent extends React.Component {
   static propTypes = SomeInternalComponent.propTypes;
}
```

(I wouldn't write/export a component like this, but I've seen it in the wild so maybe it makes sense to support it.)

Expected output:

```ts
declare module 'component' {
  import {Component} from 'react';

  export interface SomeComponentProps {
    someString?: string;
  }

  export default class SomeComponent extends Component<SomeComponentProps, any> {
    render(): JSX.Element;
  }
}
```