### PR TITLE
fix(npm): add "types" entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.24.0",
   "description": "Create typescript definitions files (d.ts) from react components",
   "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "bin": {
     "react2dts": "cli.js"
   },


### PR DESCRIPTION
This fixes the ts error `error TS7016: Could not find a declaration file for module 'react-to-typescript-definitions'`.