### PR TITLE
feat: support any name for namespace import of `prop-types`

### DIFF
--- a/src/typings.ts
+++ b/src/typings.ts
@@ -221,7 +221,7 @@ function getPropTypesName(ast: AstQuery): string|undefined {
       /:source StringLiteral[@value == 'prop-types']
     ]
     /:specifiers *[
-      / Identifier[@name == 'PropTypes']
+      ImportNamespaceSpecifier || / Identifier[@name == 'PropTypes']
     ]
     /:local Identifier
   `);

--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -99,3 +99,6 @@ test('Parsing should create preact definition', t => {
 test('Parsing should suppport props-types repo', t => {
   compare(t, 'path', 'prop-types.jsx', 'prop-types.d.ts', {});
 });
+test('Parsing should suppport props-types repo (with a default import)', t => {
+  compare(t, 'path', 'prop-types-default-import.jsx', 'prop-types.d.ts', {});
+});

--- a/tests/prop-types-default-import.jsx
+++ b/tests/prop-types-default-import.jsx
@@ -1,10 +1,10 @@
 import {Component} from 'react';
-import * as P from 'prop-types';
+import PropTypes from 'prop-types';
 
 export default class extends Component {
 
     static propTypes = {
-      optionalString: P.string
+      optionalString: PropTypes.string
     };
 
     render() {


### PR DESCRIPTION
Before only `import * as PropTypes from 'prop-types';` was supported. Now any name can be chosen, e.g. `import * as P from 'prop-types';`.