### PR TITLE
feat: support named imports from `prop-types`

### DIFF
--- a/tests/es7-class-babeled-to-es6.d.ts
+++ b/tests/es7-class-babeled-to-es6.d.ts
@@ -1,0 +1,58 @@
+declare module 'component' {
+  import {Component} from 'react';
+
+  import Message from './path/to/Message';
+
+  export type MyComponentOptionalEnum = 'News' | 'Photos' | 1 | 2;
+
+  export type MyComponentOptionalUnion = string | number;
+
+  export interface MyComponentOptionalObjectWithShape {
+    color?: string;
+    fontSize?: number;
+  }
+
+  export type MyComponentRequiredUnion = any[] | boolean;
+
+  export interface MyComponentRequiredArrayOfObjectsWithShape {
+    color?: string;
+    fontSize?: number;
+  }
+
+  export interface MyComponentDeeplyNested {
+    arrayInDeeplyNested?: {
+      foo?: number;
+    }[];
+  }
+
+  export interface MyComponentProps {
+    /**
+     * This is a jsdoc comment for optionalAny.
+     */
+    optionalAny?: any;
+    optionalArray?: any[];
+    optionalBool?: boolean;
+    optionalFunc?: (...args: any[]) => any;
+    optionalNumber?: number;
+    optionalObject?: Object;
+    optionalString?: string;
+    optionalNode?: React.ReactNode;
+    optionalElement?: React.ReactElement<any>;
+    optionalMessage?: typeof Message;
+    optionalEnum?: MyComponentOptionalEnum;
+    optionalUnion?: MyComponentOptionalUnion;
+    optionalArrayOf?: number[];
+    optionalObjectWithShape?: MyComponentOptionalObjectWithShape;
+    requiredFunc: (...args: any[]) => any;
+    requiredAny: any;
+    requiredUnion: MyComponentRequiredUnion;
+    requiredArrayOf: string[];
+    requiredArrayOfObjectsWithShape: MyComponentRequiredArrayOfObjectsWithShape[];
+    deeplyNested: MyComponentDeeplyNested[];
+    requiredSymbol: typeof Symbol;
+  }
+
+  export class MyComponent extends Component<MyComponentProps, any> {
+    render(): JSX.Element;
+  }
+}

--- a/tests/es7-class-babeled-to-es6.js
+++ b/tests/es7-class-babeled-to-es6.js
@@ -1,0 +1,48 @@
+import { Component, createElement } from 'react';
+import { any, array, arrayOf, bool, element, func, instanceOf, node, number, object, oneOf, oneOfType, shape, string, symbol } from 'prop-types';
+import Message from './path/to/Message';
+
+class MyComponent extends Component {
+
+  render() {
+    return createElement('div', null);
+  }
+}
+MyComponent.propTypes = {
+  /**
+   * This is a jsdoc comment for optionalAny.
+   */
+  optionalAny: any,
+  optionalArray: array,
+  optionalBool: bool,
+  optionalFunc: func,
+  optionalNumber: number,
+  optionalObject: object,
+  optionalString: string,
+  optionalNode: node,
+  optionalElement: element,
+  optionalMessage: instanceOf(Message),
+  optionalEnum: oneOf(['News', 'Photos', 1, 2]),
+  optionalUnion: oneOfType([string, number]),
+  optionalArrayOf: arrayOf(number),
+  optionalObjectWithShape: shape({
+    color: string,
+    fontSize: number
+  }),
+  requiredFunc: func.isRequired,
+  requiredAny: any.isRequired,
+  requiredUnion: oneOfType([array, bool]).isRequired,
+  requiredArrayOf: arrayOf(string).isRequired,
+  requiredArrayOfObjectsWithShape: arrayOf(shape({
+    color: string,
+    fontSize: number
+  })).isRequired,
+  deeplyNested: arrayOf(shape({
+    arrayInDeeplyNested: arrayOf(shape({
+      foo: number
+    }))
+  })).isRequired,
+  requiredSymbol: symbol.isRequired
+};
+
+export { MyComponent };

--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -66,6 +66,12 @@ test('Parsing should create definition from babeled es7 class component', t => {
   };
   compare(t, 'component', 'es7-class-babeled.js', 'es7-class.d.ts', opts);
 });
+test('Parsing should create definition from es7 class component babeled to es6', t => {
+  const opts: react2dts.IOptions = {
+    instanceOfResolver: (): string => './path/to/Message'
+  };
+  compare(t, 'component', 'es7-class-babeled-to-es6.js', 'es7-class-babeled-to-es6.d.ts', opts);
+});
 test('Parsing should create definition from es7 class component with separate default export', t => {
   compare(t, 'component', 'es7-class-separate-export.jsx', 'es7-class-separate-export.d.ts');
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": [
       "dom",
       "es5",
+      "es2015.core",
       "es2015.iterable",
       "es2015.promise"
     ],


### PR DESCRIPTION
Named imports from `prop-types` are generated when converting an es7 module to es6 with Babel. Therefore we should probably support that.