### PR TITLE
feat: support named exports as default

### DIFF
--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -108,3 +108,6 @@ test('Parsing should suppport props-types repo', t => {
 test('Parsing should suppport props-types repo (with a default import)', t => {
   compare(t, 'path', 'prop-types-default-import.jsx', 'prop-types.d.ts', {});
 });
+test('Parsing should support an SFC with default export babeled to es6', t => {
+  compare(t, 'component', 'stateless-export-as-default.js', 'stateless-export-as-default.d.ts');
+});

--- a/tests/stateless-export-as-default.d.ts
+++ b/tests/stateless-export-as-default.d.ts
@@ -1,0 +1,8 @@
+declare module 'component' {
+  export interface ComponentProps {
+    text: string;
+    className?: string;
+  }
+
+  export default function Component(props: ComponentProps): JSX.Element;
+}

--- a/tests/stateless-export-as-default.js
+++ b/tests/stateless-export-as-default.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Component = ({ className, text }) => React.createElement(
+  'div',
+  { className: className },
+  text
+);
+
+Component.displayName = 'Component';
+
+Component.propTypes = {
+  text: PropTypes.string.isRequired,
+  className: PropTypes.string
+};
+
+export { Component as default };


### PR DESCRIPTION
Add support for `export { Component as default };`

The diff looks big but the reason for that is that I split `getComponentExportType` into multiple smaller functions. The only new code is in `isNamedExportAsDefault`.

Related question: Should the typings for SFCs really have no import of `React`? Isn't that needed for the `JSX` namespace?