### PR TITLE
Wrap function type in parentheses

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -58,7 +58,7 @@ export function getTypeFromPropType(node: IASTNode, instanceOfResolver = default
         result.type = 'boolean';
         break;
       case 'func':
-        result.type = '(...args: any[]) => any';
+        result.type = '((...args: any[]) => any)';
         break;
       case 'number':
         result.type = 'number';

--- a/tests/parse-prop-types-test.ts
+++ b/tests/parse-prop-types-test.ts
@@ -65,7 +65,7 @@ test('The PropType parser should return a generic function for func prop types',
     }
   };
   const expected = {
-    type: '(...args: any[]) => any',
+    type: '((...args: any[]) => any)',
     optional: true
   };
   t.deepEqual(getTypeFromPropType(ast, instanceOfResolver), expected);
@@ -86,7 +86,7 @@ test('The PropType parser should return a generic required function for func.isR
     }
   };
   const result: IProp = getTypeFromPropType(ast, instanceOfResolver);
-  t.is(result.type, '(...args: any[]) => any');
+  t.is(result.type, '((...args: any[]) => any)');
   t.is(result.optional, false);
 });
 test('The PropType parser should return number for number prop types', t => {


### PR DESCRIPTION
Hey there,

I'd like to submit a small change, which'd help us integrate your nice package into our build pipeline.

We currently have a problem with the following use-case:

```
...
    someProp: PropTypes.oneOfType([ PropTypes.string, PropTypes.func ])
...
```

Here's what's generated:

```typescript
export type ComponentSomeProp = (...args: any[])=>any | string;
```

What we do want is either `((...args: any[])=>any) | string` or maybe even `Function | string`.

What do you think?