### PR TITLE
test(wallaby): exclude cli-test

### DIFF
--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -9,7 +9,8 @@ module.exports = function(wallaby) {
       {pattern: 'node_modules/dts-dom/bin/index.d.ts', instrument: false}
     ],
     tests: [
-      'tests/**/*-test.ts'
+      'tests/**/*-test.ts',
+      '!tests/cli-test.ts',
     ],
     env: {
       type: 'node'


### PR DESCRIPTION
Since `cli.js` requires `'./dist/src/index'` I don't think we can make this work with wallaby without having a `tsc` watcher running at the same time to update the dist file.