### PR TITLE
fix: avoid any for oneOf arrays with identifiers

### DIFF
--- a/tests/es6-class.d.ts
+++ b/tests/es6-class.d.ts
@@ -3,7 +3,7 @@ declare module 'component' {
 
   import Message from './path/to/Message';
 
-  export type ComponentOptionalEnum = 'News' | 'Photos' | 1 | 2;
+  export type ComponentOptionalEnum = "News" | "Photos" | 1 | 2;
 
   export type ComponentOptionalUnion = string | number;
 

--- a/tests/es7-class-babeled-to-es6.d.ts
+++ b/tests/es7-class-babeled-to-es6.d.ts
@@ -3,7 +3,7 @@ declare module 'component' {
 
   import Message from './path/to/Message';
 
-  export type MyComponentOptionalEnum = 'News' | 'Photos' | 1 | 2;
+  export type MyComponentOptionalEnum = "News" | "Photos" | 1 | 2;
 
   export type MyComponentOptionalUnion = string | number;
 

--- a/tests/references-in-proptypes.d.ts
+++ b/tests/references-in-proptypes.d.ts
@@ -1,7 +1,8 @@
 declare module 'component' {
   import {Component} from 'react';
 
-  export type SomeComponentSomeOneOf = 'foo' | 'bar';
+  export type SomeComponentSomeOneOf = "foo" | "bar";
+  export type SomeComponentAnotherOneOf = "foo" | "bar";
 
   export interface SomeComponentSomeShape {
     string?: string;
@@ -9,6 +10,7 @@ declare module 'component' {
 
   export interface SomeComponentProps {
     someOneOf?: SomeComponentSomeOneOf;
+    anotherOneOf?: SomeComponentAnotherOneOf;
     someShape?: SomeComponentSomeShape;
   }
 

--- a/tests/references-in-proptypes.jsx
+++ b/tests/references-in-proptypes.jsx
@@ -1,11 +1,15 @@
 import React from 'react';
 
+const FOO = 'foo';
+const BAR = 'bar';
 const fooOrBar = ['foo', 'bar'];
+const fooOrBarWithConsts = [FOO, BAR];
 const shape = { string: React.PropTypes.string };
 
 export default class SomeComponent extends React.Component {
    static propTypes = {
      someOneOf: React.PropTypes.oneOf(fooOrBar),
+     anotherOneOf: React.PropTypes.oneOf(fooOrBarWithConsts),
      someShape: React.PropTypes.shape(shape)
    };
 }


### PR DESCRIPTION
Avoid `any`s in union types that are generated for `oneOf` with an array of identifiers, e.g.:

```js
const FOO = 'foo';
const BAR = 'bar';
const fooOrBar = [FOO, BAR];

export default class SomeComponent extends React.Component {
   static propTypes = {
     someOneOf: React.PropTypes.oneOf(fooOrBar)
   };
}
```

now results in:

```ts
export type SomeComponentSomeOneOf = "foo" | "bar";

export interface SomeComponentProps {
  someOneOf?: SomeComponentSomeOneOf;
}
```

instead of:

```ts
export type SomeComponentSomeOneOf = any | any;
```