### PR TITLE
Add a test-case with wrong types for inheritance

### DIFF
--- a/tests/custom-inheritance.d.ts
+++ b/tests/custom-inheritance.d.ts
@@ -1,0 +1,17 @@
+declare module 'component' {
+  import {Component} from 'react';
+
+  export interface ParentComponentProps {
+  }
+
+  export class ParentComponent extends Component<ParentComponentProps, any> {
+    render(): JSX.Element;
+  }
+
+  export interface ChildComponentProps {
+  }
+
+  export class ChildComponent extends ParentComponent {
+      render(): JSX.Element;
+  }
+}

--- a/tests/custom-inheritance.jsx
+++ b/tests/custom-inheritance.jsx
@@ -1,0 +1,13 @@
+import { Component } from 'react';
+
+export class ParentComponent extends Component {
+  render() {
+    return <div />
+  }
+}
+
+export class ChildComponent extends ParentComponent {
+  render() {
+    return <div />
+  }
+}

--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -114,3 +114,6 @@ test('Parsing should support an SFC with default export babeled to es6', t => {
 test('Parsing should suppport components that extend PureComponent', t => {
   compare(t, 'component', 'pure-component.jsx', 'pure-component.d.ts');
 });
+test('Parsing should suppport components that extend a custom react component', t => {
+  compare(t, 'component', 'custom-inheritance.jsx', 'custom-inheritance.d.ts');
+});


### PR DESCRIPTION
Don't think that we should merge it, but I though it'd be worth to have a test-case to start from.

This is more of an issue than a PR at the moment.

Problem: we currently always rely on the parent class name coming from React module and accepting certain type parameters, which in case of normal inheritance is not always the case.

I don't know if it was a deliberate to not support it, if not — would be nice to decide wether it deserves a proper fix or not.