### PR TITLE
chore: update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,7 +159,7 @@
       "integrity": "sha512-7dsoPp7r33mdPcxukSrs9WVQgI96fiqffC7K4XvXJnSrTtJov3x1CJUgid7msJ8yCbfkmXJoKJ3HXyQIwZD0NQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.4.1"
+        "@types/node": "9.4.7"
       }
     },
     "@types/node": {
@@ -8766,7 +8766,7 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "read-pkg": {
@@ -9670,7 +9670,7 @@
         "builtin-modules": "1.1.1",
         "chalk": "2.3.0",
         "commander": "2.14.1",
-        "diff": "3.4.0",
+        "diff": "3.5.0",
         "glob": "7.1.2",
         "js-yaml": "3.10.0",
         "minimatch": "3.0.4",


### PR DESCRIPTION
When running `npm i` on my machine the `package-lock.json` file is updated by npm.