### PR TITLE
feat: Object property (dot notation) components

### DIFF
--- a/tests/multiple-components-dot-notation-default.d.ts
+++ b/tests/multiple-components-dot-notation-default.d.ts
@@ -1,0 +1,23 @@
+declare module 'component' {
+  import * as React from 'react';
+
+  export interface ComponentProps {
+      optionalAny?: any;
+  }
+
+  const Component: React.FC<ComponentProps> & {
+    OtherComponent: typeof Component2;
+    AnotherComponent: typeof Component3;
+  };
+
+  export default Component;
+
+  export interface Component2Props {
+      optionalString?: string;
+  }
+
+  const Component2: React.FC<Component2Props>;
+
+  const Component3: React.FC;
+
+}

--- a/tests/multiple-components-dot-notation-default.jsx
+++ b/tests/multiple-components-dot-notation-default.jsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+const Component = ({ optionalAny }) => <div />;
+Component.propTypes = {
+  optionalAny: React.PropTypes.any,
+};
+
+const Component2 = () => <div />;
+
+const Component3 = () => <div />;
+
+Component2.propTypes = {
+  optionalString: React.PropTypes.string,
+};
+
+Component.OtherComponent = Component2
+Component.AnotherComponent = Component3
+
+export default Component;

--- a/tests/multiple-components-dot-notation.d.ts
+++ b/tests/multiple-components-dot-notation.d.ts
@@ -1,0 +1,20 @@
+declare module 'component' {
+  import * as React from 'react';
+
+  export interface ComponentProps {
+      optionalAny?: any;
+  }
+
+  const Component: React.FC<ComponentProps> & {
+    OtherComponent: typeof ComponentX;
+  };
+
+  export default Component;
+
+  export interface ComponentXProps {
+      optionalString?: string;
+  }
+
+  const ComponentX: React.FC<ComponentXProps>;
+
+}

--- a/tests/multiple-components-dot-notation.jsx
+++ b/tests/multiple-components-dot-notation.jsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+const Component = ({ optionalAny }) => <div />;
+Component.propTypes = {
+  optionalAny: React.PropTypes.any,
+};
+
+const ComponentX = () => <div />;
+
+ComponentX.propTypes = {
+  optionalString: React.PropTypes.string,
+};
+
+Component.OtherComponent = ComponentX
+
+export default Component;

--- a/tests/multiple-components-object-default.d.ts
+++ b/tests/multiple-components-object-default.d.ts
@@ -1,0 +1,24 @@
+declare module 'component' {
+  import * as React from 'react';
+
+  export interface Component2Props {
+      optionalString?: string;
+  }
+
+  export const Component2: React.FC<Component2Props>;
+
+  export interface ComponentProps {
+      optionalAny?: any;
+  }
+
+  const Component: React.FC<ComponentProps>;
+
+  const Composed: {
+      Component: typeof Component;
+      Asdf: typeof Component2;
+  };
+
+  export default Composed;
+
+}
+

--- a/tests/multiple-components-object-default.jsx
+++ b/tests/multiple-components-object-default.jsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+const Component = ({ optionalAny }) => <div />;
+Component.propTypes = {
+  optionalAny: React.PropTypes.any,
+};
+
+export const Component2 = () => <div />;
+
+Component2.propTypes = {
+  optionalString: React.PropTypes.string,
+};
+
+const Composed = {
+  Component,
+  Asdf: Component2,
+};
+
+export default Composed;

--- a/tests/multiple-components-object-unnamed-default.d.ts
+++ b/tests/multiple-components-object-unnamed-default.d.ts
@@ -13,11 +13,11 @@ declare module 'component' {
 
     const Component: React.FC<ComponentProps>;
 
-    const Composed: {
+    const _default: {
         Component: typeof Component;
         Asdf: typeof Component2;
     };
 
-    export default Composed;
+    export default _default;
 
 }

--- a/tests/multiple-components-object-unnamed-default.jsx
+++ b/tests/multiple-components-object-unnamed-default.jsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+const Component = ({ optionalAny }) => <div />;
+Component.propTypes = {
+  optionalAny: React.PropTypes.any,
+};
+
+export const Component2 = () => <div />;
+
+Component2.propTypes = {
+  optionalString: React.PropTypes.string,
+};
+
+export default {
+  Component,
+  Asdf: Component2,
+};

--- a/tests/multiple-components-object.d.ts
+++ b/tests/multiple-components-object.d.ts
@@ -1,0 +1,20 @@
+declare module 'component' {
+  import * as React from 'react';
+
+  export interface ComponentProps {
+    optionalAny?: any;
+  }
+
+  const Component: React.FC<ComponentProps>;
+
+  export interface Component2Props {
+    optionalString?: string;
+  }
+
+  const Component2: React.FC<Component2Props>;
+
+  export const Composed: {
+    Component: typeof Component;
+    Component2: typeof Component2;
+  };
+}

--- a/tests/multiple-components-object.jsx
+++ b/tests/multiple-components-object.jsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+const Component = ({ optionalAny }) => <div />;
+Component.propTypes = {
+  optionalAny: React.PropTypes.any,
+};
+
+const Component2 = () => <div />;
+
+Component2.propTypes = {
+  optionalString: React.PropTypes.string,
+};
+
+export const Composed = {
+  Component,
+  Component2,
+};

--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -127,6 +127,30 @@ test("Parsing should create definition from default export that's an object of c
     'multiple-components-object-default.d.ts'
   );
 });
+test("Parsing should create definition from unnamed default export that's an object of components", (t) => {
+  compare(
+    t,
+    'component',
+    'multiple-components-object-unnamed-default.jsx',
+    'multiple-components-object-unnamed-default.d.ts'
+  );
+});
+test('Parsing should add dot notation members for component', (t) => {
+  compare(
+    t,
+    'component',
+    'multiple-components-dot-notation.jsx',
+    'multiple-components-dot-notation.d.ts'
+  );
+});
+test('Parsing should add dot notation members for default export component', (t) => {
+  compare(
+    t,
+    'component',
+    'multiple-components-dot-notation-default.jsx',
+    'multiple-components-dot-notation-default.d.ts'
+  );
+});
 test('Parsing should create definition from class import PropTypes and instanceOf dependency', (t) => {
   compare(
     t,

--- a/tests/parsing-test.ts
+++ b/tests/parsing-test.ts
@@ -111,6 +111,22 @@ test('Parsing should create definition from class extending Component', (t) => {
     'import-react-component.d.ts'
   );
 });
+test('Parsing should create definition from component exported as an object of components', (t) => {
+  compare(
+    t,
+    'component',
+    'multiple-components-object.jsx',
+    'multiple-components-object.d.ts'
+  );
+});
+test("Parsing should create definition from default export that's an object of components", (t) => {
+  compare(
+    t,
+    'component',
+    'multiple-components-object-default.jsx',
+    'multiple-components-object-default.d.ts'
+  );
+});
 test('Parsing should create definition from class import PropTypes and instanceOf dependency', (t) => {
   compare(
     t,


### PR DESCRIPTION
Hi, not sure if this is going beyond the scope of the lib, but I thought I'd put it up for consideration.
I found myself needing to use this lib for components with 'dot notation' (e.g `Card.Container`).
This PR would allow for typing various combinations of this pattern with components defined in the same file (using intersection types where necessary).

For example:
```jsx
export default {
  Container,
  Content
}
```
becomes
```ts
const _default: {
    Container: typeof Container;
    Content: typeof Content;
};

export default _default;
```
&nbsp;
```jsx
const Card = () => [...]
Card.Container = Container
Card.Content = Content
export default Card
```
becomes
```ts
const Card: React.FC<CardProps> & {
  Container: typeof Container;
  Content: typeof Content;
};

export default Component;
```

PS I'm not very familiar with `astq` so there may be better ways of doing the AST queries I added.
