### PR TITLE
Resolve PropTypes.elementType to type React.ElementType

### DIFF
--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -89,6 +89,9 @@ export function getTypeFromPropType(
       case 'element':
         result.type = 'React.ReactElement<any>';
         break;
+      case 'elementType':
+        result.type = 'React.ElementType<any>';
+        break;
       case 'union':
         result.type = type.types
           .map((unionType: string) => unionType)

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,11 @@ function getSimpleType(
         dom.create.namedTypeReference('React.ReactElement<any>'),
         !required
       );
+    case 'elementType':
+      return getTypeDeclaration(
+        dom.create.namedTypeReference('React.ElementType<any>'),
+        !required
+      );
     case 'symbol':
       return getTypeDeclaration(
         dom.create.namedTypeReference('Symbol'),


### PR DESCRIPTION
`PropTypes.elementType` was added with prop-types 15.7.0, but was missing from type resolving so far.

Extended `getSimpleType` as also `getTypeFromPropType` to resolve `PropTypes.elementType` to related type `React.ElementType`.